### PR TITLE
[wip] jobs: allow jobs to be sent with fully defined configs for outputs

### DIFF
--- a/db/types.go
+++ b/db/types.go
@@ -102,13 +102,21 @@ const (
 	ComputeClassDolbyVisionMezzQC ComputeClass = "doViMezzQC"
 )
 
+// TranscodeOutputConfig represents configurations for a single output
+type TranscodeOutputConfig = Preset
+
 // TranscodeOutput represents a transcoding output. It's a combination of the
 // preset and the output file name.
 type TranscodeOutput struct {
 	// Presetmap for the output
 	//
-	// required: true
-	Preset PresetMap `redis-hash:"presetmap,expand" json:"presetmap"`
+	// required: false
+	Preset PresetMap `redis-hash:"presetmap,expand,omitempty" json:"presetmap"`
+
+	// Config for the output
+	//
+	// required: false
+	Config *TranscodeOutputConfig `redis-hash:"transcodeoutput,expand,omitempty"`
 
 	// Filename for the output
 	//

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/NYTimes/encoding-wrapper v0.2.0
 	github.com/NYTimes/gizmo v1.2.17
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/aws/aws-sdk-go-v2 v0.12.0
 	github.com/aws/aws-sdk-go v1.24.2
+	github.com/aws/aws-sdk-go-v2 v0.12.0
 	github.com/bitmovin/bitmovin-api-sdk-go v1.23.0-alpha.0
 	github.com/cbsinteractive/hybrik-sdk-go v0.0.0-20190917134456-4f19da2dc743
 	github.com/flavioribeiro/zencoder v0.0.0-20161215190743-745874544382

--- a/provider/hybrik/element_assemblers.go
+++ b/provider/hybrik/element_assemblers.go
@@ -29,7 +29,7 @@ func (p *hybrikProvider) defaultElementAssembler(cfg jobCfg) ([][]hybrik.Element
 
 	idx := 0
 	for _, outputCfg := range cfg.outputCfgs {
-		element, err := p.transcodeElementFromPreset(outputCfg.localPreset, fmt.Sprintf(transcodeElementIDTemplate, idx),
+		element, err := p.transcodeElementFromPreset(outputCfg.transcodeCfg, fmt.Sprintf(transcodeElementIDTemplate, idx),
 			cfg, outputCfg.filename)
 		if err != nil {
 			return nil, err
@@ -48,7 +48,7 @@ func (p *hybrikProvider) dolbyVisionElementAssembler(cfg jobCfg) ([][]hybrik.Ele
 	presets := map[string]db.Preset{}
 	presetsWithoutAudio := map[string]db.Preset{}
 	for _, outputCfg := range cfg.outputCfgs {
-		preset := outputCfg.localPreset
+		preset := outputCfg.transcodeCfg
 		presets[outputCfg.filename] = preset
 
 		// removing audio so we can processing this separately

--- a/provider/hybrik/hdr.go
+++ b/provider/hybrik/hdr.go
@@ -136,7 +136,7 @@ func dolbyVisionEnabledOnAllPresets(cfgs map[string]outputCfg) (bool, error) {
 	record := struct{ doViPresetFound, nonDoViPresetFound bool }{}
 
 	for _, cfg := range cfgs {
-		if enabled := cfg.localPreset.Video.DolbyVisionSettings.Enabled; enabled {
+		if enabled := cfg.transcodeCfg.Video.DolbyVisionSettings.Enabled; enabled {
 			record.doViPresetFound = true
 		} else {
 			record.nonDoViPresetFound = true

--- a/provider/hybrik/legacy_dovi.go
+++ b/provider/hybrik/legacy_dovi.go
@@ -37,7 +37,7 @@ const (
 func (p *hybrikProvider) dolbyVisionLegacyElementAssembler(cfg jobCfg) ([][]hybrik.Element, error) {
 	presetsWithoutAudio := map[string]db.Preset{}
 	for _, outputCfg := range cfg.outputCfgs {
-		preset := outputCfg.localPreset
+		preset := outputCfg.transcodeCfg
 
 		// removing audio so we can processing this separately
 		preset.Audio = db.AudioPreset{}

--- a/service/transcode_params.go
+++ b/service/transcode_params.go
@@ -17,8 +17,9 @@ type NewTranscodeJobInputPayload struct {
 
 	// list of outputs in this job
 	Outputs []struct {
-		FileName string `json:"fileName"`
-		Preset   string `json:"preset"`
+		FileName string                    `json:"fileName"`
+		Config   *db.TranscodeOutputConfig `json:"config,omitempty"`
+		Preset   string                    `json:"preset,omitempty"`
 	} `json:"outputs"`
 
 	// provider to use in this job


### PR DESCRIPTION
This is a quick proposal with a strategy to remove the need to send presets and jobs separately to the transcoding-api. In this PR, we've updated the logic to check if a job output config is defined by a preset name first then falls back to checking for an explicit config.

I've implemented support for recognizing this in the Hybrik provider. If we choose to continue with this approach, we should update other providers to throw a useful error if they don't yet support jobs with explicit configs if configs are provided.

Example payload (tested working):
```
{
	"source": "s3://vtg-tsymborski-test-bucket/sources/bbb_360p_1380k_30s_5MB.mp4",
	"provider": "hybrik",
	"outputs": [
		{
			"fileName": "bbb_200kbps_360p.mp4",
			"config": {
				"container": "mp4",
				"rateControl": "CBR",
				"twoPass": false,
				"video": {
					"profile": "high",
					"height": "360",
					"codec": "h264",
					"bitrate": "200000",
					"gopSize": "60",
					"gopMode": "fixed",
					"interlaceMode": "progressive"
				}
			}
		}
	]
}
```

There may be a good case for making this more explicit and creating a new method in the provider interface (something like `TranscodeWithCfgs`, renaming the existing function to `TranscodeWithPresets`) to avoid implicit logic in the existing `Transcode` functions. The current implementation will seamlessly allow for both in the same config.